### PR TITLE
move external keys for broadcasts

### DIFF
--- a/app/models/broadcast.rb
+++ b/app/models/broadcast.rb
@@ -1,12 +1,8 @@
 class Broadcast < ApplicationRecord
   belongs_to :song
   belongs_to :station
-  has_many :external_keys, as: :externally_identifyable, dependent: :destroy
 
   validates :broadcasted_at, presence: true
 
   scope :of_song, ->(song) { where(song: song) }
-  scope :broadcasted_at_around, ->(time) {
-    where(broadcasted_at: Range.new(time - 15.minutes, time + 15.minutes))
-  }
 end

--- a/app/models/broadcast/finders/srf.rb
+++ b/app/models/broadcast/finders/srf.rb
@@ -4,35 +4,19 @@ class Broadcast::Finders::Srf
   end
 
   def self.find_or_initialize_by(srf_api_songlog_broadcast)
-    new(srf_api_songlog_broadcast).find_or_initialize
-  end
-
-  def find_or_initialize
-    return find_external_key.externally_identifyable if find_external_key.present?
-
-    broadcast_with_new_external_key
+    new(srf_api_songlog_broadcast).find_or_initialize_broadcast
   end
 
   def srf3_station
     @srf3_station ||= Station.find_by!(name: 'SRF3')
   end
 
-  def find_external_key
-    @find_external_key ||= ExternalKey.broadcasts
-                                      .of_station(srf3_station)
-                                      .find_by(identifier: @srf_api_songlog_broadcast.id)
-  end
-
-  def broadcast_with_new_external_key
+  def find_or_initialize_broadcast
     srf3_station.broadcasts
                 .of_song(@srf_api_songlog_broadcast.song)
-                .broadcasted_at_around(@srf_api_songlog_broadcast.broadcasted_at)
-                .first_or_initialize.tap do |broadcast|
+                .find_or_initialize_by(external_key: @srf_api_songlog_broadcast.id)
+                .tap do |broadcast|
       broadcast.broadcasted_at = @srf_api_songlog_broadcast.broadcasted_at
-      broadcast.external_keys.new(
-        station: srf3_station,
-        identifier: @srf_api_songlog_broadcast.id
-      )
     end
   end
 end

--- a/app/models/external_key.rb
+++ b/app/models/external_key.rb
@@ -8,5 +8,4 @@ class ExternalKey < ApplicationRecord
   scope :of_station, ->(station) { where(station: station) }
   scope :artists, -> { where(externally_identifyable_type: 'Artist') }
   scope :songs, -> { where(externally_identifyable_type: 'Song') }
-  scope :broadcasts, -> { where(externally_identifyable_type: 'Broadcast') }
 end

--- a/db/migrate/20200613143238_add_external_key_to_broadcasts.rb
+++ b/db/migrate/20200613143238_add_external_key_to_broadcasts.rb
@@ -1,0 +1,5 @@
+class AddExternalKeyToBroadcasts < ActiveRecord::Migration[6.0]
+  def change
+    add_column :broadcasts, :external_key, :string
+  end
+end

--- a/db/migrate/20200613143549_migrate_broadcast_external_keys.rb
+++ b/db/migrate/20200613143549_migrate_broadcast_external_keys.rb
@@ -1,0 +1,60 @@
+class MigrateBroadcastExternalKeys < ActiveRecord::Migration[6.0]
+  def up
+    ActiveRecord::Base.transaction do
+      copy_from_external_keys_to_broadcasts
+      delete_external_keys
+    end
+  end
+
+  def down
+    # not intended
+  end
+
+  private
+
+  def copy_from_external_keys_to_broadcasts
+    execute(copy_from_external_keys_to_broadcasts_sql)
+  end
+
+  def delete_external_keys
+    ExternalKey.broadcasts.destroy_all
+  end
+
+  def copy_from_external_keys_to_broadcasts_sql
+    <<~SQL
+      WITH migrated_broadcasts AS (
+        SELECT ek.externally_identifyable_id   AS broadcast_id
+             , ek.identifier                   AS target_external_key
+             , b.song_id                       AS song_id
+             , b.station_id                    AS station_id
+             , b.broadcasted_at                AS broadcasted_at
+             , b.created_at                    AS created_at
+             , b.updated_at                    AS updated_at
+          FROM external_keys ek
+         INNER JOIN broadcasts b ON b.id = ek.externally_identifyable_id
+                                AND COALESCE(b.external_key, '') != ek.identifier
+         WHERE ek.externally_identifyable_type = 'Broadcast'
+      )
+      INSERT INTO broadcasts (
+          id
+        , external_key
+        , song_id
+        , station_id
+        , broadcasted_at
+        , created_at
+        , updated_at
+      )
+      SELECT mb.broadcast_id
+           , mb.target_external_key
+           , mb.song_id
+           , mb.station_id
+           , mb.broadcasted_at
+           , mb.created_at
+           , mb.updated_at
+        FROM migrated_broadcasts mb
+        ON CONFLICT (id)
+        DO UPDATE
+        SET external_key = EXCLUDED.external_key
+    SQL
+  end
+end

--- a/db/migrate/20200613143613_add_index_on_broadcasts_station_id_external_key.rb
+++ b/db/migrate/20200613143613_add_index_on_broadcasts_station_id_external_key.rb
@@ -1,0 +1,5 @@
+class AddIndexOnBroadcastsStationIdExternalKey < ActiveRecord::Migration[6.0]
+  def change
+    add_index :broadcasts, %i[station_id external_key], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_05_140917) do
+ActiveRecord::Schema.define(version: 2020_06_13_143613) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,7 +28,9 @@ ActiveRecord::Schema.define(version: 2020_06_05_140917) do
     t.datetime "broadcasted_at", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "external_key"
     t.index ["song_id"], name: "index_broadcasts_on_song_id"
+    t.index ["station_id", "external_key"], name: "index_broadcasts_on_station_id_and_external_key", unique: true
     t.index ["station_id", "song_id", "broadcasted_at"], name: "index_broadcasts_on_station_id_and_song_id_and_broadcasted_at", unique: true
     t.index ["station_id"], name: "index_broadcasts_on_station_id"
   end

--- a/test/fixtures/broadcasts.yml
+++ b/test/fixtures/broadcasts.yml
@@ -2,3 +2,4 @@ yesterday_20200605_broadcast:
   song: beatles_yesterday
   station: srf3
   broadcasted_at: 2020-06-05T16:00:00+00:00
+  external_key: 'YESTERDAY-20200605-BROADCAST'

--- a/test/fixtures/external_keys.yml
+++ b/test/fixtures/external_keys.yml
@@ -7,8 +7,3 @@ yesterday_song_srf3:
   station: srf3
   identifier: "YESTERDAY"
   externally_identifyable: beatles_yesterday (Song)
-
-yesterday_20200605_broadcast_srf3:
-  station: srf3
-  identifier: "YESTERDAY-20200605-BROADCAST"
-  externally_identifyable: yesterday_20200605_broadcast (Broadcast)

--- a/test/models/broadcast/finders/srf_test.rb
+++ b/test/models/broadcast/finders/srf_test.rb
@@ -12,9 +12,8 @@ class Broadcast::Finders::SrfTest < ActiveSupport::TestCase
     Broadcast::Finders::Srf.find_or_initialize_by(srf_api_songlog_broadcast_new_broadcast).tap do |broadcast|
       assert broadcast.new_record?
       assert_equal songs(:beatles_yesterday), broadcast.song
-      assert broadcast.external_keys.size.positive?
-      assert_equal 'YESTERDAY-20200606-BROADCAST', broadcast.external_keys.first.identifier
-      assert_equal stations(:srf3), broadcast.external_keys.first.station
+      assert_equal 'YESTERDAY-20200606-BROADCAST', broadcast.external_key
+      assert_equal stations(:srf3), broadcast.station
     end
   end
 

--- a/test/models/external_key_test.rb
+++ b/test/models/external_key_test.rb
@@ -32,10 +32,4 @@ class ExternalKeyTest < ActiveSupport::TestCase
       external_keys(:yesterday_song_srf3).destroy
     end
   end
-
-  test '.broadcasts' do
-    assert_difference -> { ExternalKey.broadcasts.count }, -1 do
-      external_keys(:yesterday_20200605_broadcast_srf3).destroy
-    end
-  end
 end


### PR DESCRIPTION
Before the external keys for broadcasts were managed in the polymorphic association `external_keys`. Since a Broadcast is a single artifact within a station anyway we can omit this kind of duplication of data.

Table `broadcasts` receives a column `external_key`, data is being moved from `external_keys` to `broadcasts`.